### PR TITLE
Call Decoder transform constructor with provided options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,7 +96,7 @@ var Encoder = exports.Encoder = function(opts) {
 
   this.setLength = this.opts.setLength || createSetLengthMethod(this.opts.lengthSize)
 
-  Transform.call(this)
+  Transform.call(this, opts)
 }
 
 util.inherits(Encoder, Transform)


### PR DESCRIPTION
This enables overriding the underlying Writable / Readable options, e.g. `highWaterMark`. 

The Decoder already passes the options to the Transform constructor.