### PR TITLE
Use "Object.assign" instead of node's deprecated "util._extend"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ exports = module.exports = function(opts) {
 exports.decode = exports
 
 var Decoder = exports.Decoder = function(opts) {
-  this.opts = util._extend({
+  this.opts = Object.assign({
     lengthSize: 4,
     maxSize: 0,
     unbuffered: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,13 +125,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.1.tgz",
-      "integrity": "sha512-HFZ4Mp26nbWk9d/BpvP0YNL6W4UoZF0VFcTw/aPPA8RpOxeFQgK+ClABGgAUXs9Y/RGX/l1vOmrqz1MQt9MNuw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.12.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -469,9 +483,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
As described in https://github.com/davedoesdev/frame-stream/issues/23 this project uses the [deprecated](https://nodejs.org/api/deprecations.html#DEP0060) `util._extend` of node's utils package in the code here in the constructor of `Decoder` to merge the options with the default ones:

https://github.com/davedoesdev/frame-stream/blob/f688aee92d2fb10f5f7959740296887c2a98aecb/lib/index.js#L12

This PR replaces it with `Object.assign()` which has been there since node 4.0.0 and this project lists `>=18` in the node engines field.

I also ran `npm audit fix` as npm prompted me to do it immediately, and it just touches dev dependencies of eslint.

I ran `npm run test` and `npm run lint` to make sure everything still works as intended.

I also ran `npm run test` with `this.opts = opts` and `this.opts = { lengthSize: 4, maxSize: 0, unbuffered: false }` to see if the tests would cover those cases, and indeed some turned red for both cases. So I think that should suffice.

Let me know what you think or if you want me to do some changes or run some other tests.


